### PR TITLE
Add additional Kraken endpoints

### DIFF
--- a/bitex/interfaces/kraken.py
+++ b/bitex/interfaces/kraken.py
@@ -92,11 +92,13 @@ class Kraken(KrakenREST):
 
     @return_api_response(fmt.withdraw)
     def withdraw(self, size, tar_addr, **kwargs):
-        raise NotImplementedError()
+        q = {'amount': size, 'key': tar_addr}
+        q.update(kwargs)
+        return self.private_query('Withdraw', params=q)
 
     @return_api_response(fmt.deposit)
     def deposit_address(self, **kwargs):
-        raise NotImplementedError()
+        return self.private_query('DepositAddresses', params=kwargs)
 
     """
     Exchange Specific Methods
@@ -147,3 +149,11 @@ class Kraken(KrakenREST):
             q['pair'] = pair
 
         return self.private_query('TradeVolume', params=q)
+
+    def deposit_methods(self, **kwargs):
+        return self.private_query('DepositMethods', params=kwargs)
+
+    def withdraw_info(self, size, tar_addr, **kwargs):
+        q = {'amount': size, 'key': tar_addr}
+        q.update(kwargs)
+        return self.private_query('WithdrawInfo', params=q)


### PR DESCRIPTION
This PR implements endpoints for Kraken for `withdraw` and `deposit_address`. It also adds exchange-specific endpoints `deposit_methods` and `withdraw_info`.

A few notes on how Kraken handles deposit addresses and withdrawals:

1) When requesting a deposit address, `method` must be specified. This must be one returned by `deposit_methods()`
2) When withdrawing funds using `withdraw`, or getting withdraw info using `withdraw_info`, the user cannot just specify an address. They should specify the key for an address that has been added to their address book inside Kraken. This key can be arbitrary text defined by the user, although I have found in practice that using the address itself as the key is a helpful way of keeping the API calls similar.