### PR TITLE
Fix Cryptopia 'currencies()'

### DIFF
--- a/bitex/interfaces/cryptopia.py
+++ b/bitex/interfaces/cryptopia.py
@@ -96,7 +96,7 @@ class Cryptopia(CryptopiaREST):
 
     @return_api_response(None)
     def currencies(self):
-        return self.public_query('GetCurrency')
+        return self.public_query('GetCurrencies')
 
     @return_api_response(None)
     def pairs(self):


### PR DESCRIPTION
This PR fixes the endpoint for Cryptopia's `currencies()` method.