### PR TITLE
Fix deadlock on Bitfinex websocket

### DIFF
--- a/bitex/api/WSS/bitfinex.py
+++ b/bitex/api/WSS/bitfinex.py
@@ -189,7 +189,7 @@ class BitfinexWSS(WSSAPI):
         log.info("BitfinexWSS.start(): Initializing Websocket connection..")
         while self.conn is None:
             try:
-                self.conn = create_connection(self.addr, timeout=3)
+                self.conn = create_connection(self.addr, timeout=10)
             except WebSocketTimeoutException:
                 self.conn = None
                 print("Couldn't create websocket connection - retrying!")

--- a/bitex/api/WSS/bitfinex.py
+++ b/bitex/api/WSS/bitfinex.py
@@ -285,6 +285,7 @@ class BitfinexWSS(WSSAPI):
                 try:
                     raw = self.conn.recv()
                 except WebSocketTimeoutException:
+                    self._receiver_lock.release()
                     continue
                 except WebSocketConnectionClosedException:
                     # this needs to restart the client, while keeping track
@@ -293,6 +294,7 @@ class BitfinexWSS(WSSAPI):
                     self._controller_q.put('restart')
                 except AttributeError:
                     # self.conn is None, idle loop until shutdown of thread
+                    self._receiver_lock.release()
                     continue
                 msg = time.time(), json.loads(raw)
                 log.debug("receiver Thread: Data Received: %s", msg)


### PR DESCRIPTION
This patchset solves a deadlock in the recv() loop of Bitfinex websocket and increases the timeout to better fit the server performance. Check commit messages for details.