### PR TITLE
Hotfix 1.2.4

### DIFF
--- a/bitex/api/REST/api.py
+++ b/bitex/api/REST/api.py
@@ -53,7 +53,7 @@ class APIClient(metaclass=ABCMeta):
         Creates a Nonce value for signature generation
         :return:
         """
-        return str(int(1000 * time.time()))
+        return str(round(1000 * time.time())) 
 
     @staticmethod
     def api_request(*args, **kwargs):

--- a/bitex/api/REST/api.py
+++ b/bitex/api/REST/api.py
@@ -53,7 +53,7 @@ class APIClient(metaclass=ABCMeta):
         Creates a Nonce value for signature generation
         :return:
         """
-        return str(round(1000 * time.time())) 
+        return str(round(100000 * time.time())) 
 
     @staticmethod
     def api_request(*args, **kwargs):


### PR DESCRIPTION
Increase `nonce` factor and use `round` to prevent flooring during integer conversion.