### PR TITLE
Apply PEP8 and 257 on all the interfaces.

### DIFF
--- a/bitex/api/REST/binance.py
+++ b/bitex/api/REST/binance.py
@@ -6,11 +6,9 @@ Documentation available at:
 # pylint: disable=too-many-arguments
 # Import Built-ins
 import logging
-import json
 import hashlib
 import hmac
 import time
-import base64
 import urllib
 import urllib.parse
 
@@ -25,15 +23,13 @@ log = logging.getLogger(__name__)
 class BinanceREST(RESTAPI):
     """Bitfinex REST API class."""
 
-    def __init__(self, key=None, secret=None, version=None,
-                 addr=None, timeout=None, config=None):
+    def __init__(self, key=None, secret=None, version=None, addr=None, timeout=None, config=None):
         """Initialize the class instance."""
         addr = 'https://api.binance.com/api'
         # We force version to None here as different endpoints require different versions,
         # so the interface will have to define the version as part of the endpoint.
-        super(BinanceREST, self).__init__(addr=addr, version=None, key=key,
-                                          secret=secret, timeout=timeout,
-                                          config=config)
+        super(BinanceREST, self).__init__(addr=addr, version=None, key=key, secret=secret,
+                                          timeout=timeout, config=config)
 
     def private_query(self, method_verb, endpoint, **request_kwargs):
         """
@@ -50,8 +46,7 @@ class BinanceREST(RESTAPI):
 
     def sign_request_kwargs(self, method_verb, endpoint, **kwargs):
         """Sign the request."""
-        req_kwargs = super(BinanceREST, self).sign_request_kwargs(endpoint,
-                                                                   **kwargs)
+        req_kwargs = super(BinanceREST, self).sign_request_kwargs(endpoint, **kwargs)
         req_kwargs['params'] = {}
         # Prepare arguments for query request.
         try:
@@ -59,25 +54,22 @@ class BinanceREST(RESTAPI):
         except KeyError:
             params = {}
 
-        params['timestamp'] = str(int(time.time()*1000))
+        params['timestamp'] = str(int(time.time() * 1000))
 
         # Build request address
         req_string = urllib.parse.urlencode(params)
 
         # generate signature
-        signature = hmac.new(self.secret.encode('utf-8'),
-                             req_string.encode('utf-8'),
+        signature = hmac.new(self.secret.encode('utf-8'), req_string.encode('utf-8'),
                              hashlib.sha256).hexdigest()
 
         req_string += '&signature=' + signature
 
-        if method_verb == "GET" :
+        if method_verb == "GET":
             req_kwargs['url'] += '?' + req_string
-        else :
+        else:
             req_kwargs['data'] = req_string
 
         req_kwargs['headers'] = {'X-MBX-APIKEY': self.key.encode('utf-8')}
 
         return req_kwargs
-
-

--- a/bitex/interface/base.py
+++ b/bitex/interface/base.py
@@ -77,8 +77,7 @@ class Interface(metaclass=abc.ABCMeta):
 
         :param verb: HTTP verb (GET, PUT, DELETE, etc)
         :param endpoint: Str
-        :param authenticate: Bool, whether to call private_query or public_query
-                             method.
+        :param authenticate: Bool, whether to call private_query or public_query method.
         :param req_kwargs: Kwargs to pass to _query / :class:`requests.Request()`
         :raise: UnsupportedPairError
         :return: :class:`requests.Response() Obj`

--- a/bitex/interface/binance.py
+++ b/bitex/interface/binance.py
@@ -2,13 +2,9 @@
 # Import Built-Ins
 import logging
 
-# Import Third-Party
-import requests
-
 # Import Homebrew
 from bitex.api.REST.binance import BinanceREST
 from bitex.interface.rest import RESTInterface
-from bitex.utils import check_version_compatibility, check_and_format_pair
 
 # Init Logging Facilities
 log = logging.getLogger(__name__)
@@ -23,7 +19,6 @@ class Binance(RESTInterface):
 
     # pylint: disable=arguments-differ
 
-
     def __init__(self, **api_kwargs):
         """Initialize class instance."""
         super(Binance, self).__init__('Binance', BinanceREST(**api_kwargs))
@@ -31,39 +26,32 @@ class Binance(RESTInterface):
     def request(self, verb, endpoint, authenticate=False, **req_kwargs):
         """Preprocess request to API."""
         return super(Binance, self).request(verb, endpoint, authenticate=authenticate,
-                                             **req_kwargs)
+                                            **req_kwargs)
 
     def _get_supported_pairs(self):
-        """
-        Generate a list of supported pairs.
-        """
+        """Return a list of supported pairs."""
         r = self.request('GET', 'v1/exchangeInfo').json()
         pairs = [entry['symbol'] for entry in r['symbols']]
         return pairs
 
-    def is_supported(self, pair):
-        return super(Binance, self).is_supported(pair)
+    # Automatically calls the RESTInterface method.
+    # def is_supported(self, pair):
+    #     return super(Binance, self).is_supported(pair)
 
     def ticker(self, pair, *args, **kwargs):
-        """
-        Return the ticker for the given pair.
-        """
+        """Return the ticker for the given pair."""
         payload = {'symbol': pair}
         payload.update(kwargs)
         return self.request('GET', 'v1/ticker/24hr', params=payload)
 
     def order_book(self, pair, *args, **kwargs):
-        """
-        Return the order book for the given pair.
-        """
+        """Return the order book for the given pair."""
         payload = {'symbol': pair}
         payload.update(kwargs)
         return self.request("GET", "v1/depth", params=payload)
 
     def trades(self, pair, *args, **kwargs):
-        """
-        Return the trades for the given pair.
-        """
+        """Return the trades for the given pair."""
         payload = {'symbol': pair}
         payload.update(kwargs)
         return self.request('GET', 'v1/trades', params=payload)
@@ -79,36 +67,26 @@ class Binance(RESTInterface):
         return self.request('POST', 'v3/order', authenticate=True, params=payload)
 
     def ask(self, pair, price, size, *args, **kwargs):
-        """
-        Place an ask order.
-        """
+        """Place an ask order."""
         return self._place_order(pair, price, size, "SELL", *args, **kwargs)
 
     def bid(self, pair, price, size, *args, **kwargs):
-        """
-        Place a bid order.
-        """
+        """Place a bid order."""
         return self._place_order(pair, price, size, "BUY", *args, **kwargs)
 
     def order_status(self, pair, order_id, *args, **kwargs):
-        """
-        Return the status of an order with the given id.
-        """
+        """Return the status of an order with the given id."""
         payload = {'symbol': pair,
                    'orderId': order_id}
         payload.update(kwargs)
         return self.request('GET', 'v3/order', authenticate=True, params=payload)
 
     def open_orders(self, *args, **kwargs):
-        """
-        Return all open orders.
-        """
+        """Return all open orders."""
         return self.request('GET', 'v3/openOrders', authenticate=True, params=kwargs)
 
     def cancel_order(self, pair, *order_ids, **kwargs):
-        """
-        Cancel the order(s) with the given id(s).
-        """
+        """Cancel the order(s) with the given id(s)."""
         results = []
         for order_id in order_ids:
             payload = {'symbol': pair,
@@ -119,9 +97,6 @@ class Binance(RESTInterface):
 
         return results if len(results) > 1 else results[0]
 
-
     def wallet(self, *args, **kwargs):
-        """
-        Return the wallet of this account.
-        """
+        """Return the wallet of this account."""
         return self.request('GET', "v3/account", True).json()['balances']

--- a/bitex/interface/binance.py
+++ b/bitex/interface/binance.py
@@ -34,10 +34,6 @@ class Binance(RESTInterface):
         pairs = [entry['symbol'] for entry in r['symbols']]
         return pairs
 
-    # Automatically calls the RESTInterface method.
-    # def is_supported(self, pair):
-    #     return super(Binance, self).is_supported(pair)
-
     def ticker(self, pair, *args, **kwargs):
         """Return the ticker for the given pair."""
         payload = {'symbol': pair}

--- a/bitex/interface/ccex.py
+++ b/bitex/interface/ccex.py
@@ -2,9 +2,6 @@
 # Import Built-Ins
 import logging
 
-# Import Third-Party
-import requests
-
 # Import Homebrew
 from bitex.api.REST.ccex import CCEXREST
 from bitex.interface.rest import RESTInterface
@@ -32,7 +29,7 @@ class CCEX(RESTInterface):
 
     def _get_supported_pairs(self):
         """Return a list of supported pairs."""
-        return requests.get('https://c-cex.com/t/pairs.json').json()['pairs']
+        return self.request('/pairs.json').json()['pairs']
 
     # Public Endpoints
     @check_and_format_pair

--- a/bitex/interface/rest.py
+++ b/bitex/interface/rest.py
@@ -13,6 +13,7 @@ log = logging.getLogger(__name__)
 
 class RESTInterface(Interface):
     """REST Interface base class."""
+
     __metaclass__ = abc.ABCMeta
 
     def __init__(self, name, rest_api):


### PR DESCRIPTION
Another round, after PR #125.

```
$ pylint --rcfile=pylint.rc bitex
Using config file ~/bitex/pylint.rc
************* Module bitex.interface.bittrex
W: 92, 4: Keyword argument before variable positional arguments list in the definition of wallet function (keyword-arg-before-vararg)
************* Module bitex.interface.binance
W: 60, 0: Unused argument 'args' (unused-argument)
************* Module bitex.api.REST.itbit
R: 61, 4: Too many local variables (16/15) (too-many-locals)
************* Module bitex.api.REST.quoine
E: 12, 0: Unable to import 'jwt' (import-error)
************* Module bitex.api.REST.binance
W: 47, 4: Parameters differ from overridden 'sign_request_kwargs' method (arguments-differ)

------------------------------------------------------------------
Your code has been rated at 9.96/10 (previous run: 9.96/10, -0.00)

$ pycodestyle --max-line-length=100 bitex
$ pydocstyle bitex
$
```