### PR TITLE
Fix failing unit test bitfinex

### DIFF
--- a/bitex/pairs.py
+++ b/bitex/pairs.py
@@ -110,7 +110,7 @@ class PairFormatter:
         """
         base = 'DSH' if base == 'DASH' else base
         quote = 'DSH' if quote == 'DASH' else quote
-        return base.lower() + quote.lower()
+        return base.upper() + quote.upper()
 
     @staticmethod
     def bittrex_formatter(base, quote):

--- a/tests/pair_tests.py
+++ b/tests/pair_tests.py
@@ -17,7 +17,7 @@ class PairTests(unittest.TestCase):
         # This excludes edge cases, which are tested separately
         self.assertEqual(pair.format_for('Kraken'), 'XXBTZUSD')
         self.assertEqual(pair.format_for('Bitstamp'), 'btcusd')
-        self.assertEqual(pair.format_for('Bitfinex'), 'btcusd')
+        self.assertEqual(pair.format_for('Bitfinex'), 'BTCUSD')
         self.assertEqual(pair.format_for('Binance'), 'BTCUSD')
         self.assertEqual(pair.format_for('Bittrex'), 'USD-BTC')
         self.assertEqual(pair.format_for('CoinCheck'), 'btc_usd')


### PR DESCRIPTION
Expect pairs to be UPPER CASE (eg BTCUSD instead of btcusd)
From what I can tell, v1 of their API is case-agnostic.  
However, upper case is what the exchange uses when it makes a request to the API.  
